### PR TITLE
Disables primitive races

### DIFF
--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species.dm
@@ -77,7 +77,7 @@ GLOBAL_LIST_EMPTY(customizable_races)
 
 /datum/species/pod
 	name = "Primal Podperson"
-	always_customizable = TRUE
+	always_customizable = FALSE
 
 /datum/species/randomize_features(mob/living/carbon/human/human_mob)
 	var/list/features = ..()

--- a/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/lizard.dm
+++ b/modular_skyrat/modules/customization/modules/mob/living/carbon/human/species/lizard.dm
@@ -58,7 +58,7 @@
 	lizard.update_body(TRUE)
 
 /datum/species/lizard/ashwalker
-	always_customizable = TRUE
+	always_customizable = FALSE
 	inherent_traits = list(
 		TRAIT_NO_UNDERWEAR,
 		TRAIT_MUTANT_COLORS,

--- a/modular_skyrat/modules/primitive_catgirls/code/species.dm
+++ b/modular_skyrat/modules/primitive_catgirls/code/species.dm
@@ -33,7 +33,7 @@
 		TRAIT_USES_SKINTONES,
 	)
 
-	always_customizable = TRUE
+	always_customizable = FALSE
 
 /datum/species/human/felinid/primitive/get_default_mutant_bodyparts()
 	return list(


### PR DESCRIPTION
Unlike all the other races, ashwalkers, icewalkers and primitive podpeople (what the fuck are primitive podpeople?) are set to be "always customizable" in the code and are not enabled/disabled in the server config. This disables them, as they likely won't be used on this server.